### PR TITLE
Add hiding/showing canvas button.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,6 +77,11 @@ class _MyHomePageState extends State<MyHomePage> {
                 flag: OverlayFlag.defaultFlag,
                 startPosition: OverlayPosition(widthLogical! * 0.1, heightLogical! * 0.1),
               );
+              FlutterOverlayWindow.shareData({
+                'width': (widthLogical! * 0.8).toInt(),
+                'height': (heightLogical! * 0.8).toInt(),
+                'enableDrag': true,
+              });
             } else {
               await FlutterOverlayWindow.closeOverlay();
             }

--- a/lib/overlay.dart
+++ b/lib/overlay.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_overlay_window/flutter_overlay_window.dart';
+
+class OverlayController{
+  int currentWidth = 0;
+  int currentHeight = 0;
+  int previousWidth = 0;
+  int previousHeight = 0;
+  bool currentEnableDrag = false;
+
+  OverlayController._internal() {
+    FlutterOverlayWindow.overlayListener.listen((data) {
+      currentWidth = data['width'];
+      currentHeight = data['height'];
+      currentEnableDrag = data['enableDrag'];
+    });
+  }
+
+  static final OverlayController _instance = OverlayController._internal();
+
+  factory OverlayController() {
+    return _instance;
+  }
+
+  Future<bool?> closeOverlay() {
+    return FlutterOverlayWindow.closeOverlay();
+  }
+
+  Future<void> resizeOverlay(int width, int height) {
+    previousWidth = currentWidth;
+    previousHeight = currentHeight;
+    currentWidth = width;
+    currentHeight = height;
+    return FlutterOverlayWindow.resizeOverlay(width, height, currentEnableDrag);
+  }
+
+  Future<void> updateEnableDrag(bool enableDrag) {
+    currentEnableDrag = enableDrag;
+    return FlutterOverlayWindow.resizeOverlay(currentWidth, currentHeight, enableDrag);
+  }
+
+  Future<void> showOverlay({
+    int height = WindowSize.fullCover,
+    int width = WindowSize.matchParent,
+    OverlayAlignment alignment = OverlayAlignment.center,
+    NotificationVisibility visibility = NotificationVisibility.visibilitySecret,
+    OverlayFlag flag = OverlayFlag.defaultFlag,
+    String overlayTitle = "overlay activated",
+    String? overlayContent,
+    bool enableDrag = false,
+    PositionGravity positionGravity = PositionGravity.none,
+    OverlayPosition? startPosition,
+  }) async {
+    currentHeight = height;
+    currentWidth = width;
+    currentEnableDrag = enableDrag;
+    return FlutterOverlayWindow.showOverlay(
+      height: height,
+      width: width,
+      alignment: alignment,
+      visibility: visibility,
+      flag: flag,
+      overlayTitle: overlayTitle,
+      overlayContent: overlayContent,
+      enableDrag: enableDrag,
+      positionGravity: PositionGravity.none,
+      startPosition: startPosition,
+    );
+  }
+}

--- a/lib/overlay_main.dart
+++ b/lib/overlay_main.dart
@@ -25,6 +25,7 @@ class MyOverlayPage extends StatefulWidget {
 
 class _MyOverlayPageState extends State<MyOverlayPage> {
   final PaintController _controller = PaintController();
+  bool isMinimize = false;
 
   @override
   Widget build(BuildContext context) {
@@ -38,30 +39,61 @@ class _MyOverlayPageState extends State<MyOverlayPage> {
             constraints: const BoxConstraints.expand(height: 48),
             color: Colors.yellow,
             child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
-                IconButton.outlined(
-                  onPressed: () {
-                    if (_controller.canUndo) _controller.undo();
-                  },
-                  icon: const Icon(Icons.undo),
+                Row(
+                  children: <Widget>[
+                    IconButton.outlined(
+                      onPressed: () {
+                        if (_controller.canUndo) _controller.undo();
+                      },
+                      icon: const Icon(Icons.undo),
+                    ),
+                    IconButton.outlined(
+                      onPressed: () {
+                        if (_controller.canRedo) _controller.redo();
+                      },
+                      icon: const Icon(Icons.redo),
+                    ),
+                    IconButton.outlined(
+                      onPressed: () {
+                        _controller.clear();
+                      },
+                      icon: const Icon(Icons.clear),
+                    ),
+                  ],
                 ),
-                IconButton.outlined(
-                  onPressed: () {
-                    if (_controller.canRedo) _controller.redo();
-                  },
-                  icon: const Icon(Icons.redo),
-                ),
-                IconButton.outlined(
-                  onPressed: () {
-                    _controller.clear();
-                  },
-                  icon: const Icon(Icons.clear),
+                Row(
+                  children: <Widget>[
+                    IconButton.outlined(
+                      onPressed: () {
+                        FlutterOverlayWindow.resizeOverlay(
+                            288,
+                            isMinimize ? 541 : 50,
+                            true
+                        );
+                        setState(() {
+                          isMinimize = !isMinimize;
+                        });
+                      },
+                      style: IconButton.styleFrom(
+                        shape: const RoundedRectangleBorder(
+                          side: BorderSide(
+                            color: Colors.black,
+                            width: 1,
+                            style: BorderStyle.solid,
+                          ),
+                        )
+                      ),
+                      icon: isMinimize ? const Icon(Icons.maximize) : const Icon(Icons.minimize),
+                    ),
+                  ],
                 ),
               ],
             ),
           ),
           Expanded(
-            child: Stack(
+            child: !isMinimize ? Stack(
               alignment: AlignmentDirectional.bottomEnd,
               children: <Widget>[
                 Container(
@@ -81,7 +113,7 @@ class _MyOverlayPageState extends State<MyOverlayPage> {
                   ),
                 ),
               ],
-            ),
+            ) : Container(),
           ),
         ],
       ),

--- a/lib/overlay_main.dart
+++ b/lib/overlay_main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
-import 'package:flutter_overlay_window/flutter_overlay_window.dart';
-
+import 'package:simple_paint_floating_overlay/overlay.dart';
 import 'package:simple_paint_floating_overlay/painter.dart';
 
 class MyOverlayApp extends StatelessWidget {
@@ -24,8 +23,15 @@ class MyOverlayPage extends StatefulWidget {
 }
 
 class _MyOverlayPageState extends State<MyOverlayPage> {
-  final PaintController _controller = PaintController();
+  OverlayController? _overlayController;
+  final PaintController _paintController = PaintController();
   bool isMinimize = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _overlayController = OverlayController();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -45,19 +51,19 @@ class _MyOverlayPageState extends State<MyOverlayPage> {
                   children: <Widget>[
                     IconButton.outlined(
                       onPressed: () {
-                        if (_controller.canUndo) _controller.undo();
+                        if (_paintController.canUndo) _paintController.undo();
                       },
                       icon: const Icon(Icons.undo),
                     ),
                     IconButton.outlined(
                       onPressed: () {
-                        if (_controller.canRedo) _controller.redo();
+                        if (_paintController.canRedo) _paintController.redo();
                       },
                       icon: const Icon(Icons.redo),
                     ),
                     IconButton.outlined(
                       onPressed: () {
-                        _controller.clear();
+                        _paintController.clear();
                       },
                       icon: const Icon(Icons.clear),
                     ),
@@ -67,10 +73,9 @@ class _MyOverlayPageState extends State<MyOverlayPage> {
                   children: <Widget>[
                     IconButton.outlined(
                       onPressed: () {
-                        FlutterOverlayWindow.resizeOverlay(
-                            288,
-                            isMinimize ? 541 : 50,
-                            true
+                        _overlayController!.resizeOverlay(
+                            _overlayController!.currentWidth,
+                            isMinimize ? _overlayController!.previousHeight : 50,
                         );
                         setState(() {
                           isMinimize = !isMinimize;
@@ -99,7 +104,8 @@ class _MyOverlayPageState extends State<MyOverlayPage> {
                 Container(
                   constraints: const BoxConstraints.expand(),
                   child: Painter(
-                      paintController: _controller
+                    overlayController: _overlayController!,
+                    paintController: _paintController,
                   ),
                 ),
                 Container(
@@ -123,18 +129,21 @@ class _MyOverlayPageState extends State<MyOverlayPage> {
   void _onDragLowerRightEdgeStart(DragStartDetails details) async {
     final double xPos = details.globalPosition.dx;
     final double yPos = details.globalPosition.dy;
-    await FlutterOverlayWindow.resizeOverlay(xPos.toInt(), yPos.toInt(), false);
+    await _overlayController!.updateEnableDrag(false);
+    await _overlayController!.resizeOverlay(xPos.toInt(), yPos.toInt());
   }
 
   void _onDragLowerRightEdgeUpdate(DragUpdateDetails details) async {
     final double xPos = details.globalPosition.dx;
     final double yPos = details.globalPosition.dy;
-    await FlutterOverlayWindow.resizeOverlay(xPos.toInt(), yPos.toInt(), false);
+    await _overlayController!.updateEnableDrag(false);
+    await _overlayController!.resizeOverlay(xPos.toInt(), yPos.toInt());
   }
 
   void _onDragLowerRightEdgeEnd(DragEndDetails details) async {
     final double xPos = details.globalPosition.dx;
     final double yPos = details.globalPosition.dy;
-    await FlutterOverlayWindow.resizeOverlay(xPos.toInt(), yPos.toInt(), true);
+    await _overlayController!.updateEnableDrag(true);
+    await _overlayController!.resizeOverlay(xPos.toInt(), yPos.toInt());
   }
 }

--- a/lib/painter.dart
+++ b/lib/painter.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
-import 'package:flutter_overlay_window/flutter_overlay_window.dart';
-
+import 'package:simple_paint_floating_overlay/overlay.dart';
 import 'package:simple_paint_floating_overlay/paint_history.dart';
 
 class Painter extends StatefulWidget {
+  final OverlayController overlayController;
   final PaintController paintController;
 
-  const Painter({required this.paintController, super.key});
+  const Painter({required this.overlayController, required this.paintController, super.key});
 
   @override
   State<Painter> createState() => _PainterState();
@@ -31,7 +31,7 @@ class _PainterState extends State<Painter> {
   }
 
   void _onPaintStart(DragStartDetails start) async {
-    await FlutterOverlayWindow.resizeOverlay(288, 541, false);
+    await widget.overlayController.updateEnableDrag(false);
     widget.paintController._paintHistory.addPaint(_getGlobalToLocalPosition(start.globalPosition));
     widget.paintController._notifyListeners();
   }
@@ -42,7 +42,7 @@ class _PainterState extends State<Painter> {
   }
 
   void _onPaintEnd(DragEndDetails end) async {
-    await FlutterOverlayWindow.resizeOverlay(288, 541, true);
+    await widget.overlayController.updateEnableDrag(true);
     widget.paintController._paintHistory.endPaint();
     widget.paintController._notifyListeners();
   }


### PR DESCRIPTION
# Tasks
closes #5 
closes #21

# Change details

- Add hiding/showing canvas button.
- Created a wrapper class for the flutter_overlay_window package and separated the role of changing the enableDrag flag from the resizeOverlay method.
- Changed to remember the size of the overlay and reproduce the size of the overlay before hiding the canvas.

# Review items

- Hiding/Showing canvas button must function properly.
- Dragging lower right edge must function properly.
- The size of the overlay should not be changed by drawing on the canvas.

# Note
Height of window top bar is hard coded yet.
This problem will be managed in different issues.